### PR TITLE
temporarily remove bad db file

### DIFF
--- a/ac1/_static/bikeshare.db
+++ b/ac1/_static/bikeshare.db
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d32fb442a808e8255f69a5a1b28e419fcc8759b35366c3e1b69bf3e0458de726
-size 124239872


### PR DESCRIPTION
The bikeshare.db file that was in the repo was the reference file for the LFS version.  

Unfortunately GitHub will not let push an LFS file to a public fork for the repository.

I think the best strategy is to remove this file from the repo, since it is not useful, and prevents someone with LFS properly configured from even cloning the repo.

The next step really should be to take a sample of the file and create a database that fits under the 100MB LFS limit.  This is a better solution all the way around as it will speed up the pages in the database chapter considerably.    This should not be that hard to do as we will just need to rerun the correct queries and change the answers in the unit tests.


